### PR TITLE
Invalid trigger workaround

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -427,11 +427,24 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
         qpCondFuncs += res
         frameFragment(FuncApp(condName,(heap++args) map (_.l), Int))
       case sil.Implies(e0, e1) =>
-        frameFragment(CondExp(translateExp(e0), functionFrameHelper(e1,renaming,functionName,args), emptyFrame))
+        val fe1 = functionFrameHelper(e1,renaming,functionName,args)
+        val cnd = translateExp(e0)
+        if (fe1 == emptyFrame){
+          emptyFrame
+        }else{
+          frameFragment(CondExp(cnd, fe1, emptyFrame))
+        }
       case sil.And(e0, e1) =>
         combineFrames(functionFrameHelper(e0,renaming,functionName,args), functionFrameHelper(e1,renaming,functionName,args))
       case sil.CondExp(con, thn, els) =>
-        frameFragment(CondExp(translateExp(con), functionFrameHelper(thn,renaming,functionName,args), functionFrameHelper(els,renaming,functionName,args)))
+        val cnd = translateExp(con)
+        val fthn = functionFrameHelper(thn,renaming,functionName,args)
+        val fels = functionFrameHelper(els,renaming,functionName,args)
+        if (fthn == fels){
+          fthn
+        }else {
+          frameFragment(CondExp(cnd, fthn, fels))
+        }
       case sil.Unfolding(_, _) =>
         // the predicate of the unfolding expression needs to have been mentioned
         // already (framing check), so we can safely ignore it now


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by **@ignore_marcoeilers** on 2017-02-07 17:57
> Original Bitbucket pull request id: 24
>
> Participants:
>
> * **@ignore_alexanderjsummers** (reviewer)
>
> Source: https://github.com/fpoli/viper-carbon/commit/097d5d6d45496f101bd205dfdf18270557dc7a54 on [`trigger-workaround`](https://github.com/fpoli/viper-carbon/tree/trigger-workaround)
> Destination: https://github.com/fpoli/viper-carbon/commit/8c382e547ce880281307df2cdffe0465901acf09 on [`master`](https://github.com/fpoli/viper-carbon/tree/master)
>
> State: **`OPEN`**

This is a workaround for some instances of what I think is Carbon issue #146 (see my comment there). 

In my case, the invalid expression is in the condition of an implication or a conditional expression where both branches are identical anyway, so the problem can be avoided by leaving out the conditional. It doesn't solve the actual problem, of course (I briefly tried to do that, but that's kind of hard if you don't really know what's going on), but it avoids it in the instances that I currently care about :)
